### PR TITLE
Add support for metadata format

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ f.e. `sudo GOBIN=/usr/bin/ go install github.com/abenz1267/pww@latest`
 
 Additionally a `-p` flag can be provided to specify a placeholder for empty text. F.e. when the player isn't running.
 
+You can also provide `-f` flag to specify the format of the text output. F.e. `pww -w spotify:title -f '{{title}} - {{artist}}'` will emit `{"class": "Playing", "text": "Song Title - Artist Name"}`. You can find more information about supported formats [here](https://github.com/altdesktop/playerctl#printing-properties-and-metadata).
+
 ### Waybar Example
 
 This is how you'd use it as a custom module in [Waybar](https://github.com/Alexays/Waybar).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ f.e. `sudo GOBIN=/usr/bin/ go install github.com/abenz1267/pww@latest`
 
 Additionally a `-p` flag can be provided to specify a placeholder for empty text. F.e. when the player isn't running.
 
-You can also provide `-f` flag to specify the format of the text output. F.e. `pww -w spotify:title -f '{{title}} - {{artist}}'` will emit `{"class": "Playing", "text": "Song Title - Artist Name"}`. You can find more information about supported formats [here](https://github.com/altdesktop/playerctl#printing-properties-and-metadata).
+You can also provide `-f` flag to specify the format of the text output. F.e. `pww -w spotify -f '{{title}} - {{artist}}'` will emit `{"class": "Playing", "text": "Song Title - Artist Name"}`. You can find more information about supported formats [here](https://github.com/altdesktop/playerctl#printing-properties-and-metadata).
 
 ### Waybar Example
 

--- a/functions.go
+++ b/functions.go
@@ -39,8 +39,13 @@ func status(player string) string {
 	return strings.TrimSpace(string(out))
 }
 
-func metadata(player, data string) string {
-	cmd := exec.Command("playerctl", fmt.Sprintf("--player=%s", player), "metadata", data)
+func metadata(player, data, format string) string {
+	params := []string{fmt.Sprintf("--player=%s", player), "metadata", data}
+	if format != "" {
+		params = append(params, "-f", format)
+	}
+
+	cmd := exec.Command("playerctl", params...)
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -35,13 +35,24 @@ func main() {
 		return
 	}
 
-	if watch == "" {
-		return
+	player := ""
+	data := ""
+
+	if watch != "" {
+		info := strings.Split(watch, ":")
+		player = info[0]
+		// data could be empty when using a custom format
+		if len(info) > 1 {
+			data = info[1]
+			// if data is empty, format should be provided
+		} else if format == "" {
+			return
+		}
 	}
 
-	info := strings.Split(watch, ":")
-	player := info[0]
-	data := info[1]
+	if player == "" {
+		return
+	}
 
 	watchPlayerMetaData(player, data, placeholder, format)
 }

--- a/main.go
+++ b/main.go
@@ -16,11 +16,13 @@ func main() {
 	var watch string
 	var placeholder string
 	var toggle string
+	var format string
 
 	pflag.StringVarP(&autopauseplayers, "autopause", "a", "", "players to autopause")
 	pflag.StringVarP(&watch, "watch", "w", "", "metadata to watch (<player>:<data>)")
 	pflag.StringVarP(&placeholder, "placeholder", "p", "", "placeholder for empty text")
 	pflag.StringVarP(&toggle, "toggle", "t", "", "toggles play/pause for the given player. Starts the player otherwise.")
+	pflag.StringVarP(&format, "format", "f", "", "format string for the output. More info: https://github.com/altdesktop/playerctl#printing-properties-and-metadata")
 	pflag.Parse()
 
 	if toggle != "" {
@@ -41,5 +43,5 @@ func main() {
 	player := info[0]
 	data := info[1]
 
-	watchPlayerMetaData(player, data, placeholder)
+	watchPlayerMetaData(player, data, placeholder, format)
 }

--- a/metadata.go
+++ b/metadata.go
@@ -9,10 +9,10 @@ import (
 	"time"
 )
 
-func watchPlayerMetaData(player, data, placeholder string) {
+func watchPlayerMetaData(player, data, placeholder, format string) {
 	infoChannel := make(chan string)
 
-	go watchMetaData(player, data, infoChannel)
+	go watchMetaData(player, data, format, infoChannel)
 	go watchMetaDataStatus(player, infoChannel)
 
 	s := status(player)
@@ -37,7 +37,7 @@ func watchPlayerMetaData(player, data, placeholder string) {
 		if val == "STATUSCHANGED" {
 			s = status(player)
 			time.Sleep(100 * time.Millisecond)
-			text = metadata(player, data)
+			text = metadata(player, data, format)
 		} else {
 			text = val
 		}
@@ -60,8 +60,13 @@ func watchPlayerMetaData(player, data, placeholder string) {
 	}
 }
 
-func watchMetaData(player, data string, infoChannel chan string) {
-	cmd := exec.Command("playerctl", fmt.Sprintf("--player=%s", player), "metadata", data, "-F")
+func watchMetaData(player, data, format string, infoChannel chan string) {
+	params := []string{fmt.Sprintf("--player=%s", player), "metadata", data, "-F"}
+	if format != "" {
+		params = append(params, "-f", format)
+	}
+
+	cmd := exec.Command("playerctl", params...)
 
 	pipe, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
Hey!

I added a small feature for allowing users to format the output of the metadata. This is useful if the user wants to see more than one metadata value or want to choose a cool custom format.

Let me know what do you think.